### PR TITLE
Fix usage of ephemeral storage

### DIFF
--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -26,6 +26,9 @@ spec:
       volumes:
         - name: trivy-pool
         {{- if .Values.pvc.enabled }}
+            persistentVolumeClaim:
+            claimName: {{ include "trivy-runner.name" . }}
+        {{- else if .Values.ephemeralPvc.enabled }}
           ephemeral:
             volumeClaimTemplate:
               spec:

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -39,6 +39,9 @@ secrets:
 
 replicas: 1
 
+ephemeralPvc:
+  enabled: false
+
 pvc:
   enabled: false
   storageClass: ""


### PR DESCRIPTION
When using ephemeral storage we have to set ephemeral config for volume claim.

Otherwise, we use default PVC config, as before